### PR TITLE
Decline installing from CDN in section VII

### DIFF
--- a/_pages/Region-Changing.md
+++ b/_pages/Region-Changing.md
@@ -99,7 +99,8 @@ Note that occasionally the eShop will inexplicably still not work for devices th
 5. Select "Install and delete all tickets"
 6. Wait. The system may appear to freeze, just give it time.
 7. Press (A) to confirm
-8. Exit with the home button
+8. Press (B) to decline installing tickets from CDN.
+9. Exit with the home button
 
 ##### Section VI - Region settings
 


### PR DESCRIPTION
Added an extra step for the FBI prompt about installing tickets from CDN. This option should be declined to prevent running into errors while importing tickets.