### PR TITLE
Skip Steelhax if you have another entrypoint

### DIFF
--- a/_pages/DSiWare-Downgrade.md
+++ b/_pages/DSiWare-Downgrade.md
@@ -21,6 +21,9 @@ This is a currently working implementation of the "FIRM partitions known-plainte
 This guide will assume the CFW 3DS is running arm9loaderhax and was setup with this guide, but will work (with slight modifications such as doing all SysNAND steps on EmuNAND) on systems running an EmuNAND. Note that the terms EmuNAND and RedNAND refer to slightly different implementations of [the same concept](http://3dbrew.org/wiki/NAND_Redirection).
 {: .notice--info}
 
+You can skip everything related to **Steel Diver: Sub Wars** and steelhax if you already have a working primary entrypoint (e.g: OOT3dHax, FreakyHax) for **the target 3DS**, and use that instead.
+{: .notice--info}
+
 {% capture notice-4 %}
 This exploit requires you to [System Transfer](http://en-americas-support.nintendo.com/app/answers/detail/a_id/13996/) from a CFW 3DS to a stock 3DS as part of the steps. System Transfers will work in the following directions *only*:    
   + New 3DS -> New 3DS    


### PR DESCRIPTION
Steelax is unnecessary if the user already owns an entrypoint (which is not unlikely, if the already have a modded console) and only introduces unnecessary steps and unreliability in such cases.