### PR TITLE
Remove extra word from DSiWare Save Inject

### DIFF
--- a/_pages/DSiWare-Downgrade-(Save-Injection).md
+++ b/_pages/DSiWare-Downgrade-(Save-Injection).md
@@ -3,7 +3,7 @@ title: "DSiWare Downgrade (Save Injection)"
 permalink: /dsiware-downgrade-(save-injection).html
 ---
 
-If you are between on version 11.0.0 or 11.1.0, you must follow this guide to downgrade your NATIVE_FIRM using DSiWare
+If you are on version 11.0.0 or 11.1.0, you must follow this guide to downgrade your NATIVE_FIRM using DSiWare
 {: .notice}
 
 This takes advantage of an oversight which allows DSiWare titles to read and write anywhere in NAND.


### PR DESCRIPTION
Simply removes an extra word from the DSiWare Downgrade (Save Injection) page (which shouldn't be there)