### PR TITLE
Clarified how to restore sysNAND

### DIFF
--- a/_pages/Installing-arm9loaderhax.md
+++ b/_pages/Installing-arm9loaderhax.md
@@ -124,7 +124,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 
 1. Open Hourglass9 from arm9loaderhax by holding (Start) on boot
 2. Go to "SysNAND Backup/Restore"
-3. Restore from `NANDmin.bin`
+3. Go to "SysNAND Restore (keep a9lh)" and restore from `NANDmin.bin`
 4. Press (Start) to reboot
   + If you get a black screen, [follow 9.2.0 ctrtransfer](9.2.0-ctrtransfer)
 5. If your backup was of a version between 3.0.0 and 4.5.0, your console will not boot until you manually download the required firmware:


### PR DESCRIPTION
A lot of people have been verifying that to restore the sysNAND they have to go to "SysNAND Restore (keep a9lh)". I feel that adding the specific menu item to the guide will help.