### PR TITLE
Clarification on re-enabling wifi 

### DIFF
--- a/_pages/en_US/2.1.0-ctrtransfer.txt
+++ b/_pages/en_US/2.1.0-ctrtransfer.txt
@@ -5,7 +5,7 @@ lang: en_US
 ref: 2.1.0-ctrtransfer
 ---
 
-If you downgrade to 2.1.0 on a 2DS or New 3DS and left Wireless Communication off, you can re-enable the wireless by removing the battery for several seconds then booting back up.
+If you downgrade to 2.1.0 on a 2DS or New 3DS and left Wireless Communication off, you can re-enable the wireless by removing the battery and unplugging the charger for several seconds then booting back up.
 {: .notice--info}
 
 If you've been using the New 3DS's microSD Management to transfer files to your SD card, this will no longer work on 2.1.0, make sure to have a microSD card reader on hand before proceeding.

--- a/_pages/en_US/Installing-arm9loaderhax.txt
+++ b/_pages/en_US/Installing-arm9loaderhax.txt
@@ -96,6 +96,7 @@ During this process, we also setup programs such as the following:
     + If you get the error "This service is not available in your region", use the System Settings to set your device's country to match the NAND region you installed with 2.1.0 ctrtransfer
     + If you get another error, [follow this troubleshooting guide](troubleshooting#ts_browser)
     + If you get a glitched screen, [follow this troubleshooting guide](troubleshooting#ts_safe_a9lh_screen)
+    + If your wifi switch is off, unplug the 3DS and remove the battery for several seconds to enable wifi
   + Press (Select) to Full Install
   + The installer will now install arm9loaderhax on your device (this is very fast)
   + Shut down your console, hold the power button until it turns off if necessary


### PR DESCRIPTION
Added extra clarification on how to re-enable wifi on 2DS and n3DS for people who are misunderstanding the troubleshooting step and leaving the AC charger plugged in.