### PR TITLE
Fix Spanish Decrypt9WIP URL not showing correctly

### DIFF
--- a/_pages/es_ES/9.2.0-ctrtransfer.txt
+++ b/_pages/es_ES/9.2.0-ctrtransfer.txt
@@ -16,8 +16,7 @@ Debido a que el objetivo del ctrtransfer 9.2.0 es solucionar problemas causados 
 #### Qué necesitas
 
 * La última versión de [GodMode9](https://github.com/d0k3/GodMode9/releases/)
-* La última versión de [Decrypt9WIP] 
-(https://github.com/d0k3/Decrypt9WIP/releases/latest/)
+* La última versión de [Decrypt9WIP](https://github.com/d0k3/Decrypt9WIP/releases/latest/)
 * La imagen ctrtransfer 9.2.0 para tu consola y región     
 *(si tu consola no corresponde a una de estas regiones, escoge la que corresponda a tu tipo de consola)*:
   +    <i class="fa fa-magnet" aria-hidden="true" title="Este es un enlace magnético. Usa un cliente torrent para descargar el archivo."></i> - [New 3DS 9.2.0 - EUR - ctrtransfer](magnet:?xt=urn:btih:fed7bfeec0e52b42a77467cfb6ffd3e9dd2d5a70&dn=9.2.0-20E%5Fctrtransfer%5Fn3ds.zip&tr=udp%3A%2F%2Ftracker.coppersurfer.tk%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=http%3A%2F%2Ftracker.opentrackr.org%3A1337%2Fannounce&tr=udp%3A%2F%2Fzer0day.ch%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.leechers-paradise.org%3A6969%2Fannounce&tr=http%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2Fexplodie.org%3A6969%2Fannounce&tr=udp%3A%2F%2F9.rarbg.com%3A2710%2Fannounce&tr=udp%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=http%3A%2F%2Fp4p.arenabg.com%3A1337%2Fannounce&tr=udp%3A%2F%2Ftracker.aletorrenty.pl%3A2710%2Fannounce&tr=http%3A%2F%2Ftracker.aletorrenty.pl%3A2710%2Fannounce&tr=http%3A%2F%2Ftracker1.wasabii.com.tw%3A6969%2Fannounce&tr=http%3A%2F%2Ftracker.baravik.org%3A6970%2Fannounce&tr=http%3A%2F%2Ftracker.tfile.me%2Fannounce&tr=udp%3A%2F%2Ftorrent.gresille.org%3A80%2Fannounce&tr=http%3A%2F%2Ftorrent.gresille.org%2Fannounce&tr=udp%3A%2F%2Ftracker.yoshi210.com%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.tiny-vps.com%3A6969%2Fannounce&tr=udp%3A%2F%2Ftracker.filetracker.pl%3A8089%2Fannounce)   


### PR DESCRIPTION
Spanish 9.2.0 ctrtransfer was not showing the url correctly for Decypt9WIP