### PR TITLE
Missed string about HBL on 11.3

### DIFF
--- a/_pages/en_US/Updating-A9LH.txt
+++ b/_pages/en_US/Updating-A9LH.txt
@@ -88,4 +88,5 @@ These steps will also update your various payloads and the AES key database.
   + **"New 3DS CPU" to "Clock+L2(x)"**
     + This will increase the framerate of many games, but may cause instability in others
     + If some games do not work properly, disable this option and try again
+    + This breaks the Homebrew Launcher on 11.3!
 13. Reinsert your SD card, then press Start to save and reboot!


### PR DESCRIPTION
Added + This breaks the Homebrew Launcher on 11.3! since it's missed (thanks Still for this!)