### PR TITLE
Stop DCIM from being deleted.

### DIFF
--- a/_pages/en_US/Installing-arm9loaderhax.txt
+++ b/_pages/en_US/Installing-arm9loaderhax.txt
@@ -224,7 +224,7 @@ You can remove your NAND backups from `/files9/` as long as you still have them 
     + Nintendo 3DS
     + arm9loaderhax.bin
     + boot.3dsx
-
+    + DCIM
 {% endcapture %}
 
 <div class="notice--info">{{ notice-7 | markdownify }}</div>


### PR DESCRIPTION
Deleting DCIM will delete any photos you saved to SD. Kinda important. Doesn't fix i10n, and there's probably more than one part of the guide that tells you to delete it, so might need some improvement.