### PR TITLE
Add clarification about link

### DIFF
--- a/_pages/en_US/Installing-arm9loaderhax.txt
+++ b/_pages/en_US/Installing-arm9loaderhax.txt
@@ -86,7 +86,9 @@ During this process, we also setup programs such as the following:
 
 1. Reinsert your SD card into your 3DS
 2. You should be on 2.1.0
-3. Go to `http://2xrsa.3ds.guide` on your 3DS
+3. Open the internet browser
+4. Press the URL button
+5. Type in "2xrsa.3ds.guide"
   + If you get the error "This service is not available in your region", use the System Settings to set your device's country to match the NAND region you installed with 2.1.0 ctrtransfer
   + If you get another error, [follow this troubleshooting guide](troubleshooting#ts_browser)
   + If you get a glitched screen, [follow this troubleshooting guide](troubleshooting#ts_safe_a9lh_screen)


### PR DESCRIPTION
People often get confused and attempt to go to the 2xrsa link using the homebrew launcher, the Google search feature, or something else.