### PR TITLE
Fixed instructions after a failed CTRTransfer

### DIFF
--- a/_pages/en_US/Troubleshooting.txt
+++ b/_pages/en_US/Troubleshooting.txt
@@ -181,10 +181,14 @@ If an error occurs during the SafeCTRTransfer process, you will be prompted to l
 1. Select "Run 0:/ctrtransfer/payload.bin"
 1. If it was successful, you will have entered GodMode9
 1. Navigate to `SDCARD` -> `ctrtransfer`
-1. Press (A) on `<serialnumber>_nand.bin` to select it, then select "NAND image options...", then select "Restore SysNAND (safe)"
-1. Press (A) to unlock SysNAND overwriting, then input the key combo given
-  + This will not overwrite your arm9loaderhax installation
-1. Input the key combo given to unlock SysNAND (lvl1) writing
+1. Press (Y) on `<serialnumber>_nand.bin` to copy it
+1. Press (B) twice to return to the main menu
+1. Navigate to `SYSNAND VIRTUAL`
+1. Press (Y) to paste `<serialnumber>_nand.bin`
+1. Press (A) to confirm
+1. Press (A) to inject into `nand.bin`
+1. Press (A) to unlock SysNAND overwriting
+1. Input the key combo given to unlock SysNAND (lvl3) writing
   + This process will take some time
 1. Press (A) to continue once it has completed
 1. Press (Start) to reboot your device


### PR DESCRIPTION
The "Restore SysNAND (safe)" in GodMode9 is only available when running from a9lh. When not running from a9lh the backup has to be restored by copying it to SysNAND Virtual.

Because of a bug in the current release of GodMode9 (v1.0.7), they key combo to unlock lvl3 writing is currently not required. This will be fixed in the next release.