### PR TITLE
Update "Updating to Boot9Strap" page

### DIFF
--- a/_pages/en_US/Updating-to-Boot9Strap.txt
+++ b/_pages/en_US/Updating-to-Boot9Strap.txt
@@ -42,7 +42,7 @@ Note that `secret_sector.bin` is needed to revert the arm9loaderhax exploit, whi
 1. Insert your SD card into your computer
 1. Copy `boot.firm` from the Luma3DS `.7z` to the root of your SD card
 1. Create a folder named `cias` on the root of your SD card if it does not already exist
-1. Copy `lumaupdater-v2.0.cia` from the Luma3DS Updater `.zip` to the `/cias/` folder on your SD card
+1. Copy `lumaupdater-v2.0.cia` to the `/cias/` folder on your SD card
 1. Create a folder named `boot9strap` on the root of your SD card
 1. Copy `GodMode9.firm` from the GodMode9 `.zip` to the `/luma/payloads/` folder on your SD card
 1. Delete any existing `.bin` payloads in the `/luma/payloads/` folder on your SD card as they will not be compatible with boot9strap compatible Luma3DS versions


### PR DESCRIPTION
As per the above steps of the guide, when you go to [https://github.com/KunoichiZ/lumaupdate/releases/latest](https://github.com/KunoichiZ/lumaupdate/releases/latest) what is offered is a direct download of lumaupdater-v2.0.cia and not as part of a .zip file.