### PR TITLE
Revert "Add alternative URLs for launching SafeB9SInstaller via browser"

### DIFF
--- a/_pages/en_US/Installing-Boot9Strap-(Browser).txt
+++ b/_pages/en_US/Installing-Boot9Strap-(Browser).txt
@@ -31,12 +31,8 @@ To use the [magnet](https://en.wikipedia.org/wiki/Magnet_URI_scheme) links on th
 
 ##### Section II - Launching SafeB9SInstaller
 
-1. Launch the browser and go to one of the following URLs on your device
+1. Launch the browser and go to one of the following URL on your device
   + `https://dukesrg.github.io/?SafeB9SInstaller.dat`
-  + `http://go.gateway-3ds.com/`
-  + `http://www.reboot.ms/3ds/load.html?Launcher.dat`
-  + `http://dukesrg.dynu.net/3ds/rop?GW17567.dat&Launcher.dat`
-  + Make sure to try each URL if the first one doesn't work (some versions cannot use the first one, and some versions cannot use the last three)
   + If you get an error, [follow this troubleshooting guide](troubleshooting#ts_browser)
 1. If the exploit was successful, you will have booted into SafeB9SInstaller
 


### PR DESCRIPTION
There is no release containing the SafeB9SInstaller `Launcher.dat` yet. This will be re-added when a new release is made.