### PR TITLE
Make Finalizing Setup less redundant

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -93,8 +93,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 
 ##### Section IV - Injecting FBI
 
-1. Reboot holding (Start) during boot to launch the Luma3DS chainloader menu
-1. Launch GodMode9 by pressing (A)
+1. Reboot holding (Start) during boot to launch GodMode9
 1. Navigate to `[0:] SDCARD` -> `cias`
 1. Press (A) on `FBI.cia` to select it, then select "CIA image options...", then select "Mount image to drive"
 1. Press (A) on the `.app` file, then select "NCCH image options", then select "Inject to H&S"
@@ -118,8 +117,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 
 ##### Section VII - Restore Health and Safety
 
-1. Reboot holding (Start) during boot to launch the Luma3DS chainloader menu
-1. Launch GodMode9 by pressing (A)
+1. Reboot holding (Start) during boot to launch GodMode9
 1. Press (Home) to bring up the action menu
 1. Select "More..."
 1. Select "Restore H&S"
@@ -127,8 +125,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 
 ##### Section VIII - CTRNAND Luma3DS
 
-1. Reboot holding (Start) during boot to launch the Luma3DS chainloader menu
-1. Launch GodMode9 by pressing (A)
+1. Return to the main menu of GodMode9
 1. Navigate to `[0:] SDCARD`
 1. Press (Y) on `boot.firm` to copy it
 1. Press (B) to return to the main menu
@@ -145,12 +142,10 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + If you do not have this folder, just proceed with the instructions
 1. Press (A) to confirm
 1. Press (Y) to paste a copy of the `luma` folder from your SD card
-1. Press (Start) to reboot
 
 ##### Section IX - NAND Backup
 
-1. Boot your device while holding (Start) to launch the Luma3DS chainloader menu
-1. Launch GodMode9 by pressing (A)
+1. Press (B) until you get to the main menu
 1. Press (Home) to bring up the action menu
 1. Select "More..."
 1. Select "Backup NAND"

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -125,7 +125,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 
 ##### Section VIII - CTRNAND Luma3DS
 
-1. Return to the main menu of GodMode9
+1. Press (B) to return to the main menu
 1. Navigate to `[0:] SDCARD`
 1. Press (Y) on `boot.firm` to copy it
 1. Press (B) to return to the main menu


### PR DESCRIPTION
Recent Luma3DS updates make it that having only one payload launches directly to that payload when holding (Start). This also removes some unnecessary reboots.