### PR TITLE
Delete CIAs after install

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -107,7 +107,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Launch Health and Safety (which is now FBI)
 1. Navigate to `SD` -> `cias`
 1. Select "\<current directory>"
-1. Select the "Install all CIAs" option, then press (A) to confirm
+1. Select the "Install and delete all CIAs" option, then press (A) to confirm
 1. Press (Home) to exit FBI
 
 ##### Section VI - DSP Dump


### PR DESCRIPTION
Users will not need these CIAs after installing them, and can save room by deleting them in the install process.