### PR TITLE
Remove double folder creation

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -48,7 +48,6 @@ During this process, we also setup programs such as the following:
     ![]({{ base_path }}/images/screenshots/cias-file-layout.png)
     {: .notice--info}
 
-1. Create a folder named `luma` on the root of your SD card
 1. Create a folder named `payloads` in the `luma` folder on your SD card
 1. Copy `GodMode9.firm` from the GodMode9 `.zip` to the `/luma/payloads/` folder on your SD card
 1. **Old 3DS and 2DS Only:** Copy the Old 3DS 11.2.0-35 otherapp payload for your region to the `/hblauncherloader/` folder on your SD card


### PR DESCRIPTION
Luma configuration already creates this folder with config.bin on the previous step and currently causes a double folder to be made