### PR TITLE
"firmware.bin" changed to "native.firm" for Luma3DS v8.0

### DIFF
--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -62,9 +62,9 @@ During this process, we also setup programs such as the following:
   + Copy `boot.firm` to the root of your SD card *(overwrite existing files)*
   + Replace this `boot.firm` with the one from [the latest release of Luma3DS](https://github.com/AuroraWright/Luma3DS/releases/latest) after updating your device later in these instructions
 1. If your device is on a version between 3.0.0 and 4.5.0 (inclusive), your device will not boot until you manually download the required firmware:
-  + Download [this file](http://nus.cdn.c.shop.nintendowifi.net/ccs/download/0004013800000002/00000056) and rename it to `firmware.bin`
+  + Download [this file](http://nus.cdn.c.shop.nintendowifi.net/ccs/download/0004013800000002/00000056) and rename it to `native.firm`
   + Download [this file](http://nus.cdn.c.shop.nintendowifi.net/ccs/download/0004013800000002/cetk)
-  + Copy `firmware.bin` and `cetk` to the `/luma/` folder on your SD card
+  + Copy `native.firm` and `cetk` to the `/luma/` folder on your SD card
   + Delete both of these files after updating your device later in these instructions
 1. Reinsert your SD card into your device
 1. Power on your device
@@ -82,7 +82,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
   + If this gives you an error, set your DNS settings to "auto"
   + If this still gives you an error and your NAND is below 9.2.0, [follow 9.2.0 CTRTransfer](9.2.0-ctrtransfer), then try updating again
 1. If your device was on a version below 9.0.0 before updating, replace `boot.firm` on the root of your SD card with the one from [the latest release of Luma3DS](https://github.com/AuroraWright/Luma3DS/releases/latest)
-1. If your device was on a version a version between 3.0.0 and 4.5.0 before updating, delete `firmware.bin` and `cetk` from the `/luma/` folder on your SD card
+1. If your device was on a version a version between 3.0.0 and 4.5.0 before updating, delete `native.firm` and `cetk` from the `/luma/` folder on your SD card
 
 ##### Section III - Launching FBI
 

--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -144,9 +144,10 @@ Browser based exploits (such as browserhax or 2xrsa) are often unstable and cras
 1. If you previously downgraded with Gateway, ensure that you are using the latest Luma3DS version (v6.2.3 or higher, at the least)
 1. If your NAND is of a version between 3.0.0 and 4.5.0, do the following:
     + Ensure that you are using the latest Luma3DS version (v6.6 or higher, at the least)
-    + Download [this file](http://nus.cdn.c.shop.nintendowifi.net/ccs/download/0004013800000002/00000056) and rename it to `firmware.bin`
+    + Download [this file](http://nus.cdn.c.shop.nintendowifi.net/ccs/download/0004013800000002/00000056) and rename it to `native.firm`
     + Download [this file](http://nus.cdn.c.shop.nintendowifi.net/ccs/download/0004013800000002/cetk)
-    + Copy `firmware.bin` and `cetk` to the `/luma/` folder on your SD card
+    + Copy `native.firm` and `cetk` to the `/luma/` folder on your SD card
+    + If you have Luma3DS version 7.1 or lower, rename `native.firm` to `firmware.bin`
     + Delete both of these files after updating your device
 1. Try following [9.2.0 CTRTransfer](9.2.0-ctrtransfer)
 1. Ask for help at [Nintendo Homebrew on Discord](https://discord.gg/MWxPgEp).


### PR DESCRIPTION
Changes in > troubleshooting.txt (Also mentioned to keep "firmware.bin" for luma v7.1 or lesser)
Changes in > finalizing-setup.txt (firmware.bin changed to native.firm for latest luma compatibility)