### PR TITLE
U cannot use soundhax on fw without browser

### DIFF
--- a/_pages/en_US/get-started-(old-3ds).txt
+++ b/_pages/en_US/get-started-(old-3ds).txt
@@ -94,7 +94,8 @@ Your device version can be found at the bottom right of the top screen of the Sy
     <tr>
       <td style="text-align: center; font-weight: bold;">9.0.0</td>
       <td style="text-align: center; font-weight: bold;">11.3.0</td>
-      <td style="text-align: center; font-weight: bold;" colspan="2"><a href="homebrew-launcher-(soundhax)">Homebrew Launcher (Soundhax)</a></td>
+      <td style="text-align: center; font-weight: bold;"></td>
+      <td style="text-align: center; font-weight: bold;"><a href="homebrew-launcher-(soundhax)">Homebrew Launcher (Soundhax)</a></td>
     </tr>
     <tr>
       <td style="text-align: center; font-weight: bold;">11.4.0</td>


### PR DESCRIPTION
U cannot use soundhax on fw without browser couse there is no otherapp for browser version lower than 7 and if u got console with fw bigger than 9.0.0 without browser it is clear that console was updated with cartrige. So u cannot use soundhax in both cases.