### PR TITLE
Fix 2xrsa NAND restore text

### DIFF
--- a/_pages/en_US/installing-boot9strap-(2xrsa).txt
+++ b/_pages/en_US/installing-boot9strap-(2xrsa).txt
@@ -54,7 +54,7 @@ title: "Installing boot9strap (2xrsa)"
 
 ___
 
-Note that *New 3DS* users who ended up on 2.1.0 after a CTRTransfer *must* [restore their NAND backup](godmode9-usage#nand_restore) befoer going to the [Finalizing Setup](finalizing-setup) page.
+Note that *New 3DS* users who ended up on 2.1.0 after a CTRTransfer *must* [restore their NAND backup](godmode9-usage#nand_restore) before going to the [Finalizing Setup](finalizing-setup) page.
 {: .notice--danger}
 
 Continue to [Finalizing Setup](finalizing-setup)

--- a/_pages/en_US/installing-boot9strap-(2xrsa).txt
+++ b/_pages/en_US/installing-boot9strap-(2xrsa).txt
@@ -54,7 +54,7 @@ title: "Installing boot9strap (2xrsa)"
 
 ___
 
-Note that *New 3DS* users who ended up on 2.1.0 after a CTRTransfer *must* [restore their NAND backup](godmode9-usage#nand_restore) between "Section II - Configuring Luma3DS" and "Section III - Updating the System" of [Finalizing Setup](finalizing-setup).
+Note that *New 3DS* users who ended up on 2.1.0 after a CTRTransfer *must* [restore their NAND backup](godmode9-usage#nand_restore) befoer going to the [Finalizing Setup](finalizing-setup) page.
 {: .notice--danger}
 
 Continue to [Finalizing Setup](finalizing-setup)


### PR DESCRIPTION
The text for restoring your NAND is outdated. Section II is now "Updating the System" and Section III is "Launching FBI". "Configuring Luma3DS" has moved to this page altogether. (From what I understand) the NAND restore should be done at this point