### PR TITLE
fix for potential boot error after ctr transfer

### DIFF
--- a/_pages/en_US/region-changing.txt
+++ b/_pages/en_US/region-changing.txt
@@ -86,6 +86,7 @@ Never format a New 2DS while on a version <11.4.0 or you will be unable to compl
 1. Press (A) to continue
 1. Press (A) to relock write permissions
 1. Press (Start) to reboot your device
+  + If you get an error with "Process Title ID: 0x0004013000004202", hold (A) + (R) + (L) + (Up) while booting to update your system from Recovery Mode
 1. Update your device by going to System Settings, then "Other Settings", then going all the way to the right and using "System Update"
   + Updates while using B9S + Luma (what you have) are safe
   + If this gives you an error, set your DNS settings to "auto"


### PR DESCRIPTION
I experienced this issue with my New 2DS LL (JPN) and saw some other people had had similar issues in the past. This is apparently from "qtm" breaking? Updating fixed it for me and others, but I needed a way to boot into the system to update.