### PR TITLE
Move the instructions on removing ntrboot to the `Installing boot9strap` page

### DIFF
--- a/_pages/en_US/flashing-ntrboot-(custom-firmware).txt
+++ b/_pages/en_US/flashing-ntrboot-(custom-firmware).txt
@@ -51,21 +51,3 @@ ___
 
 Continue to [Installing boot9strap (ntrboot)](installing-boot9strap-(ntrboot))
 {: .notice--primary}
-
-___
-
-##### Section III - Removing ntrboot
-
-This is an optional section that will allow you to restore your flashcart to its original state.
-{: .notice--info}
-
-Do not follow this section until you have already completed [Installing boot9strap (ntrboot)](installing-boot9strap-(ntrboot)) on **the target 3DS**.
-{: .notice--warning}
-
-1. Launch the Luma3DS chainloader by holding (Start) during boot on **the source 3DS**
-1. Select "ntrboot_flasher"
-1. Select "Restore Flash"
-1. Press (Y) to proceed
-1. Wait until the process is completed
-1. Press (B) to return to the main menu
-1. Select "EXIT" to power off **the source 3DS**

--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -63,5 +63,20 @@ ___
 Continue to [Finalizing Setup](finalizing-setup)
 {: .notice--primary}
 
-If you would like to restore your flashcart to its original state (to allow it to be used for its standard functions), you can now follow the last section of [Flashing ntrboot (Custom Firmware)](flashing-ntrboot-(custom-firmware))
+___
+
+##### Section V - Removing ntrboot
+
+This is an optional section that will allow you to restore your flashcart to its original state (to allow it to be used for its standard functions).
+{: .notice--info}
+
+Do not follow this section until you have completed the rest of the instructions on this page.
 {: .notice--warning}
+
+1. Launch the Luma3DS chainloader by holding (Start) during boot on **the source 3DS**
+1. Select "ntrboot_flasher"
+1. Select "Restore Flash"
+1. Press (Y) to proceed
+1. Wait until the process is completed
+1. Press (B) to return to the main menu
+1. Select "EXIT" to power off **the source 3DS**


### PR DESCRIPTION
This will help with confusion a bit, not needing to jump between pages.
This also places them in the right place, so that users will not have to worry about keeping track of when to restore their flashcarts.
Sorry for the incredibly long commit message :P