### PR TITLE
Add that white screen may appear instead of boot.nds error for game injection

### DIFF
--- a/_pages/en_US/installing-boot9strap-(dsiware-game-injection).txt
+++ b/_pages/en_US/installing-boot9strap-(dsiware-game-injection).txt
@@ -93,7 +93,7 @@ Use a [save manager](https://github.com/J-D-K/JKSM/releases/latest) to backup an
 1. Press (Start) to reboot **the source 3DS**
 1. Launch your DSiWare game on **the source 3DS**
 1. Tap the screen or press any button to start the game and test if the save is functional
-  + If your game has an error about `boot.nds`, **then the exploit has been successful**
+  + If your game has an error about `boot.nds` or a white screen, **then the exploit has been successful**
   + If your game has an error about corrupted or inaccessible save data, confirm that you copied **the contents of** the `savedata` folder and not the `savedata` folder itself
   + If your game behaves normally and does not give you an error about `boot.nds`, then you should stop and figure out what went wrong
   + If you get a black screen, [follow this troubleshooting guide](troubleshooting#twl_broken)


### PR DESCRIPTION
When using 4swordshax (Japanese sudokuhax) the boot.nds error is replaced with a white screen. Some people are confused when they dont see the error and think the exploit has failed so it is a good idea to add a note about this. Previously this was only present for save injection's guide page but it is the case for game injection aswell.