### PR TITLE
Remove load parts from single 3ds system part

### DIFF
--- a/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
+++ b/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
@@ -34,9 +34,6 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 
 1. Launch `ak2i_ntrcardhax_flasher_dsi.nds` on your device using your flashcart
 1. Press (A) to continue
-1. Press (X) to "load flashrom"
-  + If you are using an Acekard 2i and wish to restore your flashcart to stock later, make a note of the "HW Rev"
-1. Press (A) to continue
 1. Press (A) to "inject ntrboothax"
 1. Press (A) to select "RETAIL"
 1. Press (B) to "EXIT"


### PR DESCRIPTION
DSi mode flasher hasn't `load` option.