### PR TITLE
update max vers for Infinity 3 R4i

### DIFF
--- a/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
+++ b/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
@@ -12,7 +12,7 @@ Note that more recent 3DS versions have blocked access to some flashcarts, and s
   + [Acekard 2i](http://www.nds-card.com/ProShow.asp?ProID=160) : <= 4.3.0
   + R4i Gold 3DS "Starter" : 4.1.0 - 4.5.0
   + R4i Ultra : <= 4.3.0
-  + Infinity 3 R4i : <= 10.1.0
+  + Infinity 3 R4i : <= 11.5.0
 
 Note that in some rare circumstances, it may be possible for the flashing process to **brick** a counterfeit flashcart and render it permanently unusable. This is unlikely, but nevertheless only original listed flashcarts are supported. To reduce the chance of receiving a counterfeit card, it is recommended that you use a reputable site to buy your flashcart (such as [NDS Card](http://www.nds-card.com/))
 {: .notice--danger}

--- a/_pages/en_US/ntrboot.txt
+++ b/_pages/en_US/ntrboot.txt
@@ -45,7 +45,7 @@ Note that more recent 3DS versions have blocked access to some flashcarts, and s
   + [Acekard 2i](http://www.nds-card.com/ProShow.asp?ProID=160) : <= 4.3.0
   + R4i Gold 3DS "Starter" : 4.1.0 - 4.5.0
   + R4i Ultra : <= 4.3.0
-  + Infinity 3 R4i : <= 10.1.0
+  + Infinity 3 R4i : <= 11.5.0
 
 {% endcapture %}
 


### PR DESCRIPTION
Nintendo has not updated anything to block cards since 7.0.0-X, so these cards should work on the latest too.