### PR TITLE
Uninstall CFW: Use correct NATIVE_FIRM version

### DIFF
--- a/gm9_scripts/uninstall_hax_retail_NEW.gm9
+++ b/gm9_scripts/uninstall_hax_retail_NEW.gm9
@@ -16,7 +16,7 @@ find -f 1:/title/00040138/20000002/content/????????.app NATIVE_NCCH
 imgmount $[NATIVE_NCCH]
 verify G:/exefs/.firm
 set NATIVE_FIRM $[GM9OUT]/NATIVE_FIRM.firm
-cp G:/exefs/.firm $[NATIVE_FIRM]
+cp -w G:/exefs/.firm $[NATIVE_FIRM]
 imgumount
 
 # Write NATIVE_FIRM to the FIRM partitions

--- a/gm9_scripts/uninstall_hax_retail_NEW.gm9
+++ b/gm9_scripts/uninstall_hax_retail_NEW.gm9
@@ -12,7 +12,7 @@ sha S:/sector0x96.bin 82F2730D2C2DA3F30165F987FDCCAC5CBAB24B4E5F65C981CD7BE6F438
 
 # grab NATIVE_FIRM out of the NCCH
 set ERRORMSG "NATIVE_FIRM not found.\nIs this a N3DS?"
-find 1:/title/00040138/20000002/content/????????.app NATIVE_NCCH
+find -f 1:/title/00040138/20000002/content/????????.app NATIVE_NCCH
 imgmount $[NATIVE_NCCH]
 verify G:/exefs/.firm
 set NATIVE_FIRM $[GM9OUT]/NATIVE_FIRM.firm

--- a/gm9_scripts/uninstall_hax_retail_OLD.gm9
+++ b/gm9_scripts/uninstall_hax_retail_OLD.gm9
@@ -8,7 +8,7 @@ set SUCCESSMSG "CFW uninstalled successfully"
 
 # grab NATIVE_FIRM out of the NCCH
 set ERRORMSG "NATIVE_FIRM not found.\nIs this a O3DS?"
-find 1:/title/00040138/00000002/content/????????.app NATIVE_NCCH
+find -f 1:/title/00040138/00000002/content/????????.app NATIVE_NCCH
 imgmount $[NATIVE_NCCH]
 verify G:/exefs/.firm
 set NATIVE_FIRM $[GM9OUT]/NATIVE_FIRM.firm

--- a/gm9_scripts/uninstall_hax_retail_OLD.gm9
+++ b/gm9_scripts/uninstall_hax_retail_OLD.gm9
@@ -12,7 +12,7 @@ find -f 1:/title/00040138/00000002/content/????????.app NATIVE_NCCH
 imgmount $[NATIVE_NCCH]
 verify G:/exefs/.firm
 set NATIVE_FIRM $[GM9OUT]/NATIVE_FIRM.firm
-cp G:/exefs/.firm $[NATIVE_FIRM]
+cp -w G:/exefs/.firm $[NATIVE_FIRM]
 imgumount
 
 # Write NATIVE_FIRM to the FIRM partitions


### PR DESCRIPTION
The current script uses `find` without parameters, which gets the alphanumerical last match since GodMode9 v1.4.0. This causes the script to, if present, flash the firm of a predownloaded update. Using the `-f` flag (alphanumerical first match) ensures the oldest firm available is used, which should always be the currently installed one.

I also added a `-w` flag (force overwrite) when copying the firm to `gm9/out` to prevent the user from skipping/renaming the firm if the file already exists, which could also cause a wrong firm to be installed.