### PR TITLE
Clarify 3DS SD Card

### DIFF
--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -16,7 +16,7 @@ title: "Installing boot9strap (ntrboot)"
 ##### Section I - Prep Work
 
 1. Power off your device
-1. Insert your SD card into your computer
+1. Insert your consoles SD card into your computer
 1. Copy `SafeB9SInstaller.firm` to the root of your SD card and rename it to `boot.firm`
 1. Copy _the contents of_ `starter.zip` to the root of your SD card
 1. Create a folder named `boot9strap` on the root of your SD card


### PR DESCRIPTION
Some people get confused and insert the Flashcard SD into their computer instead of the console SD as you can see in https://gbatemp.net/threads/the-3ds-guide-site-ntrboothax.485236/ and https://github.com/Plailect/Guide/issues/1361