### PR TITLE
Update installing-boot9strap-(ntrboot).txt

### DIFF
--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -124,4 +124,4 @@ Do not follow this section until you have completed the rest of the instructions
 1. Press (A) to proceed
 1. Wait until the process is completed
 1. Press (A) to return to the main menu
-1. Select "Exit" to power off your device
+1. Press (B) to power off your device


### PR DESCRIPTION
ntrboot_flasher 0.3.1 has no exit menu. We can press И or choose Poweroff or reboot