### PR TITLE
Add R4i B9S (preinstalled ntrboot).

### DIFF
--- a/_pages/en_US/ntrboot.txt
+++ b/_pages/en_US/ntrboot.txt
@@ -28,6 +28,7 @@ Note that carts with a "Time Bomb" will no longer be able to launch `.nds` files
 | R4 3D Revolution |  | No | None | None | All | |
 | R4i Gold 3DS Deluxe "Starter" |  | No | 4.1.0 - 4.5.0 | <= 1.4.5 | All | |
 | R4i Ultra |  | No | <= 4.3.0 | <= 1.4.5 | All | |
+| [R4i-B9S] (http://3ds-flashcard.com/home/69-r4i-b9sr4-card-supports-b9s3ds-cfw-1.html) | $19.90 | Probably (Date Unknown) | n/a | n/a | n/a | Has ntrboot pre-installed, convertible to R4i-SDHC 3DS RTS. |
 
   ![]({{ "/images/screenshots/ntrboot-flashcarts.png" | absolute_url }})
   {: .notice--info}


### PR DESCRIPTION
The http://www.nds-card.com/ store *doesn't* sell this card, so the link is to another that does. If nds-card ever starts selling it, the link should be changed. It would also be reasonable to simply remove the link and let people find it on their own.

Or not do this at all.

¯\\\_(ツ)_/¯

Again, I don't know how to *test* this. Strong peer review required. Adding a table row looks simple enough anyway.