### PR TITLE
Add Ace3ds X (comes w/ ntrboot and switches between it and DS cart)

### DIFF
--- a/_pages/en_US/ntrboot.txt
+++ b/_pages/en_US/ntrboot.txt
@@ -28,6 +28,7 @@ Note that carts with a "Time Bomb" will no longer be able to launch `.nds` files
 | R4 3D Revolution |  | No | None | None | All | |
 | R4i Gold 3DS Deluxe "Starter" |  | No | 4.1.0 - 4.5.0 | <= 1.4.5 | All | |
 | R4i Ultra |  | No | <= 4.3.0 | <= 1.4.5 | All | |
+| [Ace3ds X] (http://ace3ds.com/ace-3ds-x-product.html) | $29 | ?? | <= 11.6.0 | <= 1.4.4 | All | Button switches between ntrboot and DS flashcart mode |
 
   ![]({{ "/images/screenshots/ntrboot-flashcarts.png" | absolute_url }})
   {: .notice--info}


### PR DESCRIPTION
This one links to the team page, leaving finding it to the reader. It is also sold at http://3ds-flashcard.com/home/65-ace3ds-x-supports-3dsds-mode.html so that URL could be used instead. Or if nds-card starts selling it, link there.