### PR TITLE
Update ntrboot links for ntrteam org

### DIFF
--- a/_pages/en_US/flashing-ntrboot-(3ds-multi-system).txt
+++ b/_pages/en_US/flashing-ntrboot-(3ds-multi-system).txt
@@ -18,7 +18,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
   + **The source 3DS**: the 3DS family device that is already running boot9strap
   + **The target 3DS**: the device on stock firmware
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(`ntr` boot9strap; not the `devkit` file)*
-* The latest release of [ntrboot_flasher](https://github.com/kitling/ntrboot_flasher/releases/latest)
+* The latest release of [ntrboot_flasher](https://github.com/ntrteam/ntrboot_flasher/releases/latest)
 
 ### Instructions
 

--- a/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
+++ b/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
@@ -14,7 +14,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 ### What you need
 
 * Your ntrboot compatible flashcart
-* The latest release of [ak2i_ntrcardhax_flasher](https://github.com/d3m3vilurr/ak2i_ntrcardhax_flasher/releases/latest) *(`dsi` flasher; not the standard flasher)*
+* The latest release of [ds_ntrboot_flasher](https://github.com/ntrteam/ds_ntrboot_flasher/releases/latest) *(`dsi` flasher; not the standard flasher)*
 
 ### Instructions
 

--- a/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
+++ b/_pages/en_US/flashing-ntrboot-(3ds-single-system).txt
@@ -22,13 +22,13 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 
 1. Power off your device
 1. Insert your flashcart's SD card into your computer
-1. Copy `ak2i_ntrcardhax_flasher_dsi.nds` to your flashcart's SD card
+1. Copy `ds_ntrboot_flasher_dsi.nds` to your flashcart's SD card
 1. Reinsert your flashcart's SD card back into your flashcart
 1. Insert your ntrboot compatible DS / DSi flashcart into your device
 
 #### Section II - Flashing ntrboot
 
-1. Launch `ak2i_ntrcardhax_flasher_dsi.nds` on your device using your flashcart
+1. Launch `ds_ntrboot_flasher_dsi.nds` on your device using your flashcart
 1. Press (A) to continue
 1. Use (Up) and (Down) to select your flashcart
 1. Press (A) to continue

--- a/_pages/en_US/flashing-ntrboot-(dsi).txt
+++ b/_pages/en_US/flashing-ntrboot-(dsi).txt
@@ -25,13 +25,13 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 
 1. Power off **the source DSi**
 1. Insert your flashcart's SD card into your computer
-1. Copy `ak2i_ntrcardhax_flasher_dsi.nds` to your flashcart's SD card
+1. Copy `ds_ntrboot_flasher_dsi.nds` to your flashcart's SD card
 1. Reinsert your flashcart's SD card back into your flashcart
 1. Insert your ntrboot compatible DS / DSi flashcart into **the source DSi**
 
 #### Section II - Flashing ntrboot
 
-1. Launch `ak2i_ntrcardhax_flasher_dsi.nds` on **the source DSi** using your flashcart
+1. Launch `ds_ntrboot_flasher_dsi.nds` on **the source DSi** using your flashcart
 1. Press (A) to continue
 1. Use (Up) and (Down) to select your flashcart
 1. Press (A) to continue

--- a/_pages/en_US/flashing-ntrboot-(dsi).txt
+++ b/_pages/en_US/flashing-ntrboot-(dsi).txt
@@ -17,7 +17,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 * Two devices 
   + **The source DSi**: the Nintendo DSi which is compatible with your flashcart
   + **The target 3DS**: the 3DS family device on stock firmware
-* The latest release of [ak2i_ntrcardhax_flasher](https://github.com/d3m3vilurr/ak2i_ntrcardhax_flasher/releases/latest) *(`dsi` flasher; not the standard flasher)*
+* The latest release of [ds_ntrboot_flasher](https://github.com/ntrteam/ds_ntrboot_flasher/releases/latest) *(`dsi` flasher; not the standard flasher)*
 
 ### Instructions
 

--- a/_pages/en_US/flashing-ntrboot-(nds).txt
+++ b/_pages/en_US/flashing-ntrboot-(nds).txt
@@ -17,7 +17,7 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 * Two devices 
   + **The source NDS / NDSL**: the Nintendo DS or Nintendo DS Lite which is compatible with your flashcart
   + **The target 3DS**: the 3DS family device on stock firmware
-* The latest release of [ak2i_ntrcardhax_flasher](https://github.com/d3m3vilurr/ak2i_ntrcardhax_flasher/releases/latest) *(standard flasher; not the `dsi` flasher)*
+* The latest release of [ds_ntrboot_flasher](https://github.com/dtrteam/ds_ntrboot_flasher/releases/latest) *(standard flasher; not the `dsi` flasher)*
 
 ### Instructions
 

--- a/_pages/en_US/flashing-ntrboot-(nds).txt
+++ b/_pages/en_US/flashing-ntrboot-(nds).txt
@@ -25,13 +25,13 @@ Note that in some rare circumstances, it may be possible for the flashing proces
 
 1. Power off **the source NDS / NDSL**
 1. Insert your flashcart's SD card into your computer
-1. Copy `ak2i_ntrcardhax_flasher.nds` to your flashcart's SD card
+1. Copy `ds_ntrboot_flasher.nds` to your flashcart's SD card
 1. Reinsert your flashcart's SD card back into your flashcart
 1. Insert your ntrboot compatible DS / DSi flashcart into **the source NDS / NDSL**
 
 #### Section II - Flashing ntrboot
 
-1. Launch `ak2i_ntrcardhax_flasher.nds` on **the source NDS / NDSL** using your flashcart
+1. Launch `ds_ntrboot_flasher.nds` on **the source NDS / NDSL** using your flashcart
 1. Press (A) to continue
 1. Use (Up) and (Down) to select your flashcart
 1. Press (A) to continue

--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -84,7 +84,7 @@ Do not follow this section until you have completed the rest of the instructions
 
 ##### What you need
 
-* The latest release of [ntrboot_flasher](https://github.com/kitling/ntrboot_flasher/releases/latest)
+* The latest release of [ntrboot_flasher](https://github.com/ntrteam/ntrboot_flasher/releases/latest)
 * The flashrom backup corresponding to your flashcart    
   + Note that if you followed "Flashing ntrboot (3DS Multi System)", the flashrom already exists in the correct location and does not need to be downloaded
   + If you do not know which HW revision you have, just try each for your cart of them. Only the correct one will allow your flashcart to launch properly from home menu, but flashing the wrong one will not brick the cart


### PR DESCRIPTION
They moved the flashers to a single repo.
~~Note that ds_ntrboot_flasher's release page still uses the old filenames; this will need to be changed at a later date.~~ That was changed already