### PR TITLE
Tweak to Section VII of DSiWare game injection

### DIFF
--- a/_pages/en_US/installing-boot9strap-(dsiware-game-injection).txt
+++ b/_pages/en_US/installing-boot9strap-(dsiware-game-injection).txt
@@ -159,16 +159,15 @@ Use a [save manager](https://github.com/J-D-K/JKSM/releases/latest) to backup an
 1. Select "Install boot9strap" and confirm
 1. Exit b9sTool, then power off your device
   + You may have to force power off by holding the power button
-1. Power on **the target 3DS**
 
 #### Section VII - Configuring Luma3DS
 
-1. Your device should have booted into the Luma3DS configuration menu
-  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#black-screen-on-sysnand-boot-after-installing-boot9strap)
+1. Boot your device while holding (Select) to launch the Luma configuration menu
 1. Use the (A) button and the D-Pad to turn on the following:    
   + **"Show NAND or user string in System Settings"**
+  + In some cases it may already be configured. If so, proceed to the next step
 1. Press (Start) to save and reboot
-  + If you get an error, just continue the next page
+  + If you get a black screen, [follow this troubleshooting guide](troubleshooting#black-screen-on-sysnand-boot-after-installing-boot9strap)
 
 ___
 


### PR DESCRIPTION
In the DSiWare game injection guide, during the system transfer, the user may be prompted to move the SD card from the source to the target (To move DSiWare titles). However, since the source's SD card has an already properly configured `config.bin`, moving the SD card from the source to the target will result to the target having an already properly configured `config.bin` as well. This will result in the user not booting into the Luma configuration menu on boot, and it will confuse users since the guide says "You should have booted into the Luma configuration menu"

I modified it so that the user is told to hold select on boot. This not only addresses the issue above, but it is a good test to determine whether the B9S installation went well.
