### PR TITLE
Clarify which SD card for installing-boot9strap-(ntrboot)

### DIFF
--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -20,7 +20,7 @@ To use the [magnet](https://en.wikipedia.org/wiki/Magnet_URI_scheme) links on th
 #### Section I - Prep Work
 
 1. Power off your device
-1. Insert your device's SD card into your computer
+1. Insert your 3DS's SD card into your computer
 1. Copy `SafeB9SInstaller.firm` to the root of your SD card and rename it to `boot.firm`
 1. Copy `boot.3dsx` to the root of your SD card
 1. Create a folder named `boot9strap` on the root of your SD card

--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -116,7 +116,7 @@ Do not follow this section until you have completed the rest of the instructions
 1. Create a folder named `ntrboot` on the root of your SD card
 1. Copy `backup.bin` from your flashrom backup `.zip` to the `/ntrboot/` folder on the root of your SD card
 1. Create a folder named `payloads` in the `luma` folder on your SD card 
-1. Copy `ntrboot_flasher.firm` from the ntrboot_flasher `.zip` to the `/luma/payloads` folder on **the source 3DS**'s SD card
+1. Copy `ntrboot_flasher.firm` to the `/luma/payloads/` folder on 3DS' SD card
 1. Reinsert your SD card back into your device
 1. Insert your ntrboot compatible DS / DSi flashcart into your device
 1. Launch ntrboot_flasher by holding (Start) during boot


### PR DESCRIPTION
Changes:

1. Clarify that the installation files (like `boot.firm`), go to the 3DS's SD card
2. ntrboot_flasher.firm does not come in a `.zip`, it comes as a direct download, so, I removed the "from the ntrboot_flasher `.zip`"
3. Removed the "**source's 3DS**" phrase as not everyone is doing multi system 3DS. Plus, it's not necessarily bad if they restore it on the freshly hacked 3DS 