### PR TITLE
Tell users to make a 3ds folder in ntrboot guide

### DIFF
--- a/_pages/en_US/installing-boot9strap-(ntrboot).txt
+++ b/_pages/en_US/installing-boot9strap-(ntrboot).txt
@@ -26,7 +26,7 @@ To use the [magnet](https://en.wikipedia.org/wiki/Magnet_URI_scheme) links on th
 1. Copy `boot.3dsx` to the root of your SD card
 1. Create a folder named `boot9strap` on the root of your SD card
 1. Copy `boot9strap.firm` and `boot9strap.firm.sha` from the boot9strap `.zip` to the `/boot9strap/` folder on your SD card
-
+1. Create a folder named `3ds` on the root of your SD card
     ![]({{ "/images/screenshots/boot9strap-ntrboot-file-layout.png" | absolute_url }})
     {: .notice--info}
 


### PR DESCRIPTION
Currently, the user is told to just put `boot.3dsx` on root. However, they are going to be running `FBI.3dsx` after this, and they won't have a `3ds` folder on root, and they never told to make one in the first place.

I left the steps order as it is in homebrew-launcher-(soundhax)

![Image](https://image.prntscr.com/image/aFYCGm8GScuRVQ09qXv7cA.png)