### PR TITLE
Fix screwups with nnid and extdata scripts

### DIFF
--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -211,11 +211,20 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 
 ## Removing an NNID without formatting your device
 
+### What you need
+
+* [`remove_nnid.gm9`]({{ "/gm9_scripts/remove_nnid.gm9" | absolute_url }})
+
+### Instructions
+
+Note that if you have any payload files other than `GodMode9.firm` in the `/luma/payloads/` folder on your SD card, holding (Start) on boot will display a "chainloader menu" where you will have to use the D-Pad and the (A) button to select "GodMode9" for these instructions. 
+{: .notice--info}
+
 1. Launch GodMode9 by holding (Start) during boot
-1. Navigate to `[1:] SYSNAND CTRNAND` -> `data` -> (32 Character ID) -> `sysdata` -> `00010038`
-1. Hold down the (R) trigger, then press (X) on `00000000` to rename this file
-1. Press (Up) once to change the name to `10000000`
-1. Press (A) to save changes
-1. Press (A) to unlock SysNAND writing, then input the key combo given
-1. Navigate back to the Main Menu
+1. Select "Scripts..."
+1. Select "remove_nnid"
+1. When prompted, press (A) to proceed
+1. Press (A) to unlock SysNAND (lvl1) writing, then input the key combo given
+1. Press (A) to continue
+1. Press (A) to relock write permissions
 1. Press (Start) to reboot your device

--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -217,9 +217,6 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 
 ### Instructions
 
-Note that if you have any payload files other than `GodMode9.firm` in the `/luma/payloads/` folder on your SD card, holding (Start) on boot will display a "chainloader menu" where you will have to use the D-Pad and the (A) button to select "GodMode9" for these instructions. 
-{: .notice--info}
-
 1. Launch GodMode9 by holding (Start) during boot
 1. Select "Scripts..."
 1. Select "remove_nnid"

--- a/gm9_scripts/remove_extdata.gm9
+++ b/gm9_scripts/remove_extdata.gm9
@@ -1,8 +1,8 @@
-# last changed: 20171111
+# last changed: 20171118
 # author: figgyc
 
-set ERRORMSG "HOME Menu extdata removal success"
-set SUCCESSMSG "HOME Menu extdata removal failed"
+set ERRORMSG "HOME Menu extdata removal failed"
+set SUCCESSMSG "HOME Menu extdata removal success"
 
 ask "This will remove the HOME Menu extdata from your SD.\n\nContinue?"
 

--- a/gm9_scripts/remove_nnid.gm9
+++ b/gm9_scripts/remove_nnid.gm9
@@ -1,11 +1,11 @@
-# last changed: 20171111
+# last changed: 20171118
 # author: figgyc
 
 ask "This will remove the NNID from your device.\n\nContinue?"
 
 
-set ERRORMSG "NNID removal success"
-set SUCCESSMSG "NNID removal failed"
+set ERRORMSG "NNID removal failed"
+set SUCCESSMSG "NNID removal success"
 
 # allow NAND modifications
 allow -a 1:/


### PR DESCRIPTION
The success/fail messages were inverted and I also forgot to add the NNID script to GodMode9 Usage in addition to Troubleshooting.