### PR TITLE
Two small tweaks

### DIFF
--- a/_pages/en_US/a9lh-to-b9s.txt
+++ b/_pages/en_US/a9lh-to-b9s.txt
@@ -138,6 +138,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Select "Backup SysNAND"
 1. Press (A) to confirm
   + This process will take some time
+  + If you get an error, make sure that you have 1.3GB of free space on your SD card
 1. Press (A) to continue
 1. Hold (R) and press (B) at the same time to eject your SD card
 1. Insert your SD card into your computer

--- a/_pages/en_US/finalizing-setup.txt
+++ b/_pages/en_US/finalizing-setup.txt
@@ -123,6 +123,7 @@ If, before following this guide, you already had an EmuNAND setup and would like
 1. Select "Backup SysNAND"
 1. Press (A) to confirm
   + This process will take some time
+  + If you get an error, make sure that you have 1.3GB of free space on your SD card
 1. Press (A) to continue
 1. Hold (R) and press (B) at the same time to eject your SD card
 1. Insert your SD card into your computer

--- a/_pages/en_US/homebrew-launcher-(soundhax).txt
+++ b/_pages/en_US/homebrew-launcher-(soundhax).txt
@@ -25,7 +25,7 @@ This means that using a Cart Update from a version containing an older Nintendo 
 * The latest release of [Soundhax](http://soundhax.com/) *(for your device and region)*
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(standard boot9strap; not the `devkit` file, not the `ntr` file)*
-* The latest release of [safehax](https://github.com/TiniVi/safehax/releases/latest) *(the `.3dsx`; not the `.smdh`)*
+* The latest release of [safehax](https://github.com/TiniVi/safehax/releases/latest) *(the `.3dsx`)*
 * The latest release of [udsploit](https://github.com/smealum/udsploit/releases/latest)
 * The latest release of [Luma3DS](https://github.com/AuroraWright/Luma3DS/releases/latest) *(the `.7z` file)*
 * The [otherapp payload](https://smealum.github.io/3ds/#otherapp) *(for your version and region)*

--- a/_pages/en_US/homebrew-launcher-(soundhax).txt
+++ b/_pages/en_US/homebrew-launcher-(soundhax).txt
@@ -25,7 +25,7 @@ This means that using a Cart Update from a version containing an older Nintendo 
 * The latest release of [Soundhax](http://soundhax.com/) *(for your device and region)*
 * The latest release of [SafeB9SInstaller](https://github.com/d0k3/SafeB9SInstaller/releases/latest)
 * The latest release of [boot9strap](https://github.com/SciresM/boot9strap/releases/latest) *(standard boot9strap; not the `devkit` file, not the `ntr` file)*
-* The latest release of [safehax](https://github.com/TiniVi/safehax/releases/latest)
+* The latest release of [safehax](https://github.com/TiniVi/safehax/releases/latest) *(the `.3dsx`; not the `.smdh`)*
 * The latest release of [udsploit](https://github.com/smealum/udsploit/releases/latest)
 * The latest release of [Luma3DS](https://github.com/AuroraWright/Luma3DS/releases/latest) *(the `.7z` file)*
 * The [otherapp payload](https://smealum.github.io/3ds/#otherapp) *(for your version and region)*


### PR DESCRIPTION
1. Small reminder in homebrew-launcher-(soundhax) to tell users to download the `.3dsx` of safehax, to reduce the "do i download smdh or 3dsx?" questions

1.  Tell users they need at least 1.3GB (to cover both O3DS _and_ N3DS) for the NAND backup
To prevent incidents like this one:

![img](https://image.prntscr.com/image/kY4MTjWFQ-aghbEkv-UU9Q.png)