### PR TITLE
Two Fixes

### DIFF
--- a/_pages/en_US/godmode9-usage.txt
+++ b/_pages/en_US/godmode9-usage.txt
@@ -218,6 +218,11 @@ To identify a `<TitleID>.gbavc.sav` file's Title ID, you can get a listing of al
 ### Instructions
 
 1. Launch GodMode9 by holding (Start) during boot
+1. Hold (R) and press (B) at the same time to eject your SD card
+1. Insert your SD card into your computer
+1. Copy `remove_nnid.gm9` to the `/gm9/scripts/` folder on your SD card
+1. Reinsert your SD card into your device
+1. Press (Home) to bring up the action menu
 1. Select "Scripts..."
 1. Select "remove_nnid"
 1. When prompted, press (A) to proceed

--- a/_pages/en_US/site-navigation.txt
+++ b/_pages/en_US/site-navigation.txt
@@ -33,6 +33,7 @@ sitemap: false
 + [Get Started (New 3DS)](get-started-(new-3ds))
 + [Get Started (Old 3DS)](get-started-(old-3ds))
 + [Get Started](get-started)
++ [GodMode9 Usage](godmode9-usage)
 + [H2testw (Windows)](h2testw-(windows))
 + [Home](/)
 + [Homebrew Launcher (Soundhax)](homebrew-launcher-(soundhax))


### PR DESCRIPTION
This pull request adds “GodMode9 Usage” to the “Site Navigation” page of the guide and also adds some missing instructions to the “Removing an NNID without formatting your device” section of the “GodMode9 Usage” page, which may have otherwise caused some confusion for users.