### PR TITLE
Added Clearer Instructions to the “Removing an NNID without formatting your device” section of the Troubleshooting Page  

### DIFF
--- a/_pages/en_US/troubleshooting.txt
+++ b/_pages/en_US/troubleshooting.txt
@@ -53,6 +53,11 @@ Note that if you have any payload files other than `GodMode9.firm` in the `/luma
 {: .notice--info}
 
 1. Launch GodMode9 by holding (Start) during boot
+1. Hold (R) and press (B) at the same time to eject your SD card
+1. Insert your SD card into your computer
+1. Copy `remove_nnid.gm9` to the `/gm9/scripts/` folder on your SD card
+1. Reinsert your SD card into your device
+1. Press (Home) to bring up the action menu
 1. Select "Scripts..."
 1. Select "remove_nnid"
 1. When prompted, press (A) to proceed


### PR DESCRIPTION
Fix #1475 